### PR TITLE
fix(logger): :bug: logger not printing debug messages

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -1,4 +1,4 @@
-import * as os from 'os'
+import { constants } from 'os'
 import { handlers } from './handler'
 import { logger } from './logger'
 import { signals, SignalsEvents } from './signal'
@@ -24,7 +24,7 @@ export const shutdown = async (
       ? signal
       : signal instanceof Error
       ? (signal as NodeJS.ErrnoException).errno
-      : os.constants.signals[signal as NodeJS.Signals]
+      : constants.signals[signal as NodeJS.Signals]
 
   logger('Shutdown exitCode:', exitCode)
 

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -6,9 +6,11 @@ import { SignalsEvents } from './signal'
  * @export
  * @interface HandlerFunction
  */
-
 export interface HandlerFunction {
   (signal?: SignalsEvents | Error): unknown
 }
 
+/**
+ * This array contains all the handler functions that will be called upon catching a signal.
+ */
 export const handlers: HandlerFunction[] = []

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
-import * as utils from './core'
+import { attachListenerForEvent, shutdown } from './core'
 import { HandlerFunction, handlers } from './handler'
-import * as DEBUG from './logger'
+import { logger } from './logger'
 import { signals, SignalsEvents } from './signal'
 
 /**
@@ -33,7 +33,7 @@ export class ShutdownCleanup {
    */
   static registerHandler(handler: HandlerFunction): void {
     handlers.push(handler)
-    DEBUG.logger('Handler:', handler.toString())
+    logger('Handler:', handler.toString())
   }
 
   /**
@@ -47,8 +47,8 @@ export class ShutdownCleanup {
   static addSignal(signal: SignalsEvents): boolean {
     if (signals.has(signal)) return false
     signals.add(signal)
-    utils.attachListenerForEvent(signal)
-    DEBUG.logger('Added signal:', signal)
+    attachListenerForEvent(signal)
+    logger('Added signal:', signal)
     return true
   }
 
@@ -62,8 +62,8 @@ export class ShutdownCleanup {
    */
   static removeSignal(signal: SignalsEvents): boolean {
     if (signals.delete(signal)) {
-      process.removeListener(signal, utils.shutdown)
-      DEBUG.logger('Removed signal:', signal)
+      process.removeListener(signal, shutdown)
+      logger('Removed signal:', signal)
       return true
     }
     return false

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,6 +1,15 @@
 const { DEBUG } = process.env
-const enabled = DEBUG && /(?:^shutdown-cleanup$|^\*$)/.test(DEBUG)
 
+/**
+ * comaptibility with the `debug` package (https://www.npmjs.com/package/debug) without the dependency.
+ */
+const enabled = DEBUG && /(?:shutdown-cleanup|^\*$)/.test(DEBUG)
+
+/**
+ * Log a debug message message
+ *
+ * @param message the debug message to show
+ */
 export const logger = (...message: unknown[]): void => {
   if (enabled) console.debug('🐞shutdown-cleanup', ...message)
 }

--- a/src/signal.ts
+++ b/src/signal.ts
@@ -19,6 +19,9 @@ export type SignalsEvents =
   | 'multipleResolves'
   | NodeJS.Signals
 
+/**
+ * Default signals to listen to.
+ */
 export const signals: Set<SignalsEvents> = new Set([
   'SIGTERM',
   'SIGHUP',

--- a/tests/__snapshots__/index.test.js.snap
+++ b/tests/__snapshots__/index.test.js.snap
@@ -1,0 +1,70 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Core functionalities Remove exit 1`] = `""`;
+
+exports[`Core functionalities exit 1`] = `
+"42
+"
+`;
+
+exports[`Core functionalities not windows machines SIGABRT 1`] = `
+"SIGABRT
+"
+`;
+
+exports[`Core functionalities not windows machines SIGHUP 1`] = `
+"SIGHUP
+"
+`;
+
+exports[`Core functionalities not windows machines SIGINT 1`] = `
+"SIGINT
+"
+`;
+
+exports[`Core functionalities not windows machines SIGTERM 1`] = `
+"SIGTERM
+"
+`;
+
+exports[`Core functionalities quit 1`] = `
+"0
+"
+`;
+
+exports[`Switch on/off debugging process.env.DEBUG= 1`] = `
+"0
+"
+`;
+
+exports[`Switch on/off debugging process.env.DEBUG=* 1`] = `
+"🐞shutdown-cleanup Handler: function () { [native code] }
+🐞shutdown-cleanup Shutting down on 0
+0
+🐞shutdown-cleanup Shutdown completed
+🐞shutdown-cleanup Shutdown exitCode: 0
+"
+`;
+
+exports[`Switch on/off debugging process.env.DEBUG=foo-bar 1`] = `
+"0
+"
+`;
+
+exports[`Switch on/off debugging process.env.DEBUG=foo-bar shutdown-cleanup 1`] = `
+"🐞shutdown-cleanup Handler: function () { [native code] }
+🐞shutdown-cleanup Shutting down on 0
+0
+🐞shutdown-cleanup Shutdown completed
+🐞shutdown-cleanup Shutdown exitCode: 0
+"
+`;
+
+exports[`Switch on/off debugging process.env.DEBUG=shutdown-cleanup 1`] = `
+"🐞shutdown-cleanup Handler: function () { [native code] }
+🐞shutdown-cleanup Shutting down on 0
+0
+🐞shutdown-cleanup Shutdown completed
+🐞shutdown-cleanup Shutdown exitCode: 0
+"
+`;

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -4,9 +4,12 @@ const os = require('os')
 
 const programFile = path.resolve(__dirname, './program.js')
 
-const forkProcess = (args) => {
+const forkProcess = (args, debug) => {
   return new Promise((resolve) => {
-    const proc = fork(programFile, args, { silent: true })
+    const proc = fork(programFile, args, {
+      silent: true,
+      env: { DEBUG: debug },
+    })
 
     let output = ''
 
@@ -24,115 +27,164 @@ const forkProcess = (args) => {
   })
 }
 
-/**
- * process.kill on win32 is dodgy at best.
- */
-describe('not windows machines', () => {
-  if (os.platform() === 'win32') return
-  test('SIGINT', async () => {
-    const args = ['-k', 'SIGINT']
+describe('Core functionalities', () => {
+  /**
+   * process.kill on win32 is dodgy at best.
+   */
+  describe('not windows machines', () => {
+    if (os.platform() === 'win32') return
+    test('SIGINT', async () => {
+      const args = ['-k', 'SIGINT']
+
+      const [code, output] = await forkProcess(args)
+
+      expect(code).toBe(os.constants.signals.SIGINT)
+      expect(output).toMatchSnapshot()
+    })
+
+    test('SIGTERM', async () => {
+      const args = ['-k', 'SIGTERM']
+
+      const [code, output] = await forkProcess(args)
+
+      expect(code).toBe(os.constants.signals.SIGTERM)
+      expect(output).toMatchSnapshot()
+    })
+
+    test('SIGHUP', async () => {
+      const args = ['-k', 'SIGHUP']
+
+      const [code, output] = await forkProcess(args)
+
+      expect(code).toBe(os.constants.signals.SIGHUP)
+      expect(output).toMatchSnapshot()
+    })
+
+    test('SIGABRT', async () => {
+      const args = ['-a', 'SIGABRT', '-k', 'SIGABRT']
+
+      const [code, output] = await forkProcess(args)
+
+      expect(code).toBe(os.constants.signals.SIGABRT)
+      expect(output).toMatchSnapshot()
+    })
+  })
+
+  test('exit', async () => {
+    const args = ['-e', '42']
 
     const [code, output] = await forkProcess(args)
 
-    expect(code).toBe(os.constants.signals.SIGINT)
-    expect(output).toMatch(/^SIGINT/)
+    expect(code).toBe(42)
+    expect(output).toMatchSnapshot()
   })
 
-  test('SIGTERM', async () => {
-    const args = ['-k', 'SIGTERM']
+  test('quit', async () => {
+    const args = ['-q']
 
     const [code, output] = await forkProcess(args)
 
-    expect(code).toBe(os.constants.signals.SIGTERM)
-    expect(output).toMatch(/^SIGTERM/)
+    expect(code).toBe(0)
+    expect(output).toMatchSnapshot()
   })
 
-  test('SIGHUP', async () => {
-    const args = ['-k', 'SIGHUP']
+  test('Remove exit', async () => {
+    const args = ['-e', '42', '-r', 'exit']
 
     const [code, output] = await forkProcess(args)
 
-    expect(code).toBe(os.constants.signals.SIGHUP)
-    expect(output).toMatch(/^SIGHUP/)
+    expect(code).toBe(42)
+    expect(output).toMatchSnapshot()
   })
 
-  test('SIGABRT', async () => {
-    const args = ['-a', 'SIGABRT', '-k', 'SIGABRT']
+  test('uncaughtException not added', async () => {
+    const args = ['--uncaught-exception']
 
     const [code, output] = await forkProcess(args)
 
-    expect(code).toBe(os.constants.signals.SIGABRT)
-    expect(output).toMatch(/^SIGABRT/)
+    expect(code).toBe(1)
+    expect(output).toMatch('foo()')
+  })
+
+  test('uncaughtException added', async () => {
+    const args = ['--uncaught-exception', '-a', 'uncaughtException']
+
+    const [code, output] = await forkProcess(args)
+
+    expect(code).toBe(1)
+    expect(output).toMatch(/^ReferenceError: foo is not defined/)
+  })
+
+  test('unhandledRejection not added', async () => {
+    const args = ['--unhandled-rejection']
+
+    const [code, output] = await forkProcess(args)
+
+    const nodejs_version = parseInt(
+      process.versions.node.split('.')[0].trim(),
+      10
+    )
+    // node v15 and above exits with a non-zero code for this
+    const exit_code = nodejs_version <= 14 ? 0 : 1
+    expect(code).toBe(exit_code)
+    const error_msg =
+      nodejs_version <= 14 ? 'UnhandledPromiseRejectionWarning' : 'Error: boom'
+    expect(output).toMatch(error_msg)
+  })
+
+  test('unhandledRejection added', async () => {
+    const args = ['--unhandled-rejection', '-a', 'unhandledRejection']
+
+    const [code, output] = await forkProcess(args)
+
+    expect(code).toBe(1)
+    expect(output).toMatch(/^Error: boom/)
   })
 })
 
-test('exit', async () => {
-  const args = ['-e', '42']
+describe('Switch on/off debugging', () => {
+  test('process.env.DEBUG=shutdown-cleanup', async () => {
+    const args = ['-q']
 
-  const [code, output] = await forkProcess(args)
+    const [code, output] = await forkProcess(args, 'shutdown-cleanup')
 
-  expect(code).toBe(42)
-  expect(output).toMatch(/^42/)
-})
+    expect(code).toBe(0)
+    expect(output).toMatchSnapshot()
+  })
 
-test('quit', async () => {
-  const args = ['-q']
+  test('process.env.DEBUG=*', async () => {
+    const args = ['-q']
 
-  const [code, output] = await forkProcess(args)
+    const [code, output] = await forkProcess(args, '*')
 
-  expect(code).toBe(0)
-  expect(output).toMatch(/^0/)
-})
+    expect(code).toBe(0)
+    expect(output).toMatchSnapshot()
+  })
 
-test('Remove exit', async () => {
-  const args = ['-e', '42', '-r', 'exit']
+  test('process.env.DEBUG=foo-bar shutdown-cleanup', async () => {
+    const args = ['-q']
 
-  const [code, output] = await forkProcess(args)
+    const [code, output] = await forkProcess(args, 'foo-bar shutdown-cleanup')
 
-  expect(code).toBe(42)
-  expect(output).toMatch('')
-})
+    expect(code).toBe(0)
+    expect(output).toMatchSnapshot()
+  })
 
-test('uncaughtException not added', async () => {
-  const args = ['--uncaught-exception']
+  test('process.env.DEBUG=foo-bar', async () => {
+    const args = ['-q']
 
-  const [code, output] = await forkProcess(args)
+    const [code, output] = await forkProcess(args, 'foo-bar')
 
-  expect(code).toBe(1)
-  expect(output).toMatch('foo()')
-})
+    expect(code).toBe(0)
+    expect(output).toMatchSnapshot()
+  })
 
-test('uncaughtException added', async () => {
-  const args = ['--uncaught-exception', '-a', 'uncaughtException']
+  test('process.env.DEBUG=', async () => {
+    const args = ['-q']
 
-  const [code, output] = await forkProcess(args)
+    const [code, output] = await forkProcess(args, '')
 
-  expect(code).toBe(1)
-  expect(output).toMatch(/^ReferenceError: foo is not defined/)
-})
-
-test('unhandledRejection not added', async () => {
-  const args = ['--unhandled-rejection']
-
-  const [code, output] = await forkProcess(args)
-
-  const nodejs_version = parseInt(
-    process.versions.node.split('.')[0].trim(),
-    10
-  )
-  // node v15 and above exits with a non-zero code for this
-  const exit_code = nodejs_version <= 14 ? 0 : 1
-  expect(code).toBe(exit_code)
-  const error_msg =
-    nodejs_version <= 14 ? 'UnhandledPromiseRejectionWarning' : 'Error: boom'
-  expect(output).toMatch(error_msg)
-})
-
-test('unhandledRejection added', async () => {
-  const args = ['--unhandled-rejection', '-a', 'unhandledRejection']
-
-  const [code, output] = await forkProcess(args)
-
-  expect(code).toBe(1)
-  expect(output).toMatch(/^Error: boom/)
+    expect(code).toBe(0)
+    expect(output).toMatchSnapshot()
+  })
 })

--- a/tests/program.js
+++ b/tests/program.js
@@ -9,13 +9,12 @@ program
   .option('-q, --quit')
   .option('-x, --uncaught-exception')
   .option('-y, --unhandled-rejection')
-  .option('--debug <name>')
 
 program.parse(process.argv)
 
 const opts = program.opts()
 
-function lookBusy() {
+const lookBusy = () => {
   let current = 0
   const timerId = setInterval(() => {
     if (current === 3) {
@@ -25,11 +24,11 @@ function lookBusy() {
   }, 100)
 }
 
+ShutdownCleanup.registerHandler(console.log)
+
 if (opts.addSignal) ShutdownCleanup.addSignal(opts.addSignal)
 
 if (opts.removeSignal) ShutdownCleanup.removeSignal(opts.removeSignal)
-
-ShutdownCleanup.registerHandler(console.log)
 
 lookBusy()
 
@@ -38,9 +37,8 @@ if (opts.uncaughtException) {
 }
 
 if (opts.unhandledRejection) {
-  const p = new Promise((resolve, reject) => {
-    if (false) resolve('never called :(')
-    else reject(new Error('boom'))
+  const p = new Promise((_, reject) => {
+    reject(new Error('boom'))
   })
 
   const badCall = async () => {


### PR DESCRIPTION
Fixed compromised compatibility with the `debug` package.

the logger was not printing debug messages unless process.env.DEBUG was equal to `shutdown-cleanup` only or `*` only.
